### PR TITLE
Prevent registering a name that is already registered

### DIFF
--- a/Xena/bot_functions/manage_commands.py
+++ b/Xena/bot_functions/manage_commands.py
@@ -32,9 +32,10 @@ class ManageCommands:
         """Enable a command"""
         try:
             interaction.response.defer()  # This could take a while
-            record = await self._db.table_command_lock.get_command_lock_record(
+            records = await self._db.table_command_lock.get_command_lock_records(
                 command_name=command_name
             )
+            record = records[0] if records else None
             record = await self._db.table_command_lock.update_command_lock_record(
                 record, is_allowed=True
             )
@@ -49,9 +50,10 @@ class ManageCommands:
         """Disable a command"""
         try:
             interaction.response.defer()  # This could take a while
-            record = await self._db.table_command_lock.get_command_lock_record(
+            records = await self._db.table_command_lock.get_command_lock_records(
                 command_name=command_name
             )
+            record = records[0] if records else None
             record = await self._db.table_command_lock.update_command_lock_record(
                 record, is_allowed=False
             )

--- a/Xena/bot_functions/manage_matches.py
+++ b/Xena/bot_functions/manage_matches.py
@@ -64,10 +64,11 @@ class ManageMatches:
             inviter_team_id = await inviter_team.get_field(TeamFields.record_id)
             inviter_team_name = await inviter_team.get_field(TeamFields.team_name)
             # Get invitee team from opposing_team_name
-            invitee_team = await self._db.table_team.get_team_record(
+            invitee_team_matches = await self._db.table_team.get_team_records(
                 team_name=opposing_team_name
             )
-            assert invitee_team, f"Team '{opposing_team_name}' not found."
+            assert invitee_team_matches, f"Team '{opposing_team_name}' not found."
+            invitee_team = invitee_team_matches[0]
             inviter_player_name = await inviter_player.get_field(
                 PlayerFields.player_name
             )
@@ -250,13 +251,17 @@ class ManageMatches:
             inviter_team_id = await selected_match_invite.get_field(
                 MatchInviteFields.from_team_id
             )
-            inviter_team = await self._db.table_team.get_team_record(
+            inviter_team_matches = await self._db.table_team.get_team_records(
                 record_id=inviter_team_id
             )
+            assert inviter_team_matches, f"Team not found."
+            inviter_team = inviter_team_matches[0]
             inviter_team_name = await inviter_team.get_field(TeamFields.team_name)
-            invitee_team = await self._db.table_team.get_team_record(
+            invitee_team_matches = await self._db.table_team.get_team_records(
                 record_id=invitee_team_id
             )
+            assert invitee_team_matches, f"Team not found."
+            invitee_team = invitee_team_matches[0]
             invitee_team_name = await invitee_team.get_field(TeamFields.team_name)
             assert (
                 inviter_team_id != invitee_team_id
@@ -341,9 +346,11 @@ class ManageMatches:
             inviter_team_id = await inviter_team.get_field(TeamFields.record_id)
             inviter_team_name = await inviter_team.get_field(TeamFields.team_name)
             # Get invitee team details from opposing_team_name
-            invitee_team = await self._db.table_team.get_team_record(
+            invitee_team_matches = await self._db.table_team.get_team_records(
                 team_name=opposing_team_name
             )
+            assert invitee_team_matches, f"Team '{opposing_team_name}' not found."
+            invitee_team = invitee_team_matches[0]
             invitee_team_details = await database_helpers.get_team_details_from_team(
                 self._db, team=invitee_team
             )

--- a/Xena/bot_functions/manage_players.py
+++ b/Xena/bot_functions/manage_players.py
@@ -130,41 +130,51 @@ class ManagePlayers:
                 discord_id=discord_id, player_name=player_name
             )
             assert players, "Player not found."
-            player = players[0]
-            player_name = await player.get_field(PlayerFields.player_name)
-            player_region = await player.get_field(PlayerFields.region)
-            player_id = await player.get_field(PlayerFields.record_id)
-            message_dict = {}
-            message_dict["player"] = player_name
-            message_dict["region"] = player_region
-            # Get cooldown info
-            cooldowns = await self._db.table_cooldown.get_cooldown_records(
-                player_id=player_id
-            )
-            cooldown: CooldownRecord = cooldowns[0] if cooldowns else None
-            if cooldown:
-                cooldown_end = await cooldown.get_field(CooldownFields.expires_at)
-                message_dict["cooldown_end"] = cooldown_end
-            # Get Team info
-            team_players = await self._db.table_team_player.get_team_player_records(
-                player_id=player_id
-            )
-            team_player = team_players[0] if team_players else None
-            if team_player:
-                team_id = await team_player.get_field(TeamPlayerFields.team_id)
-                teams = await self._db.table_team.get_team_records(record_id=team_id)
-                assert teams, "Player team not found"
-                team = teams[0] if teams else None
-                team_name = await team.get_field(TeamFields.team_name)
-                is_captain = await team_player.get_field(TeamPlayerFields.is_captain)
-                is_co_cap = await team_player.get_field(TeamPlayerFields.is_co_captain)
-                message_dict["team"] = team_name
-                team_role = "member"
-                team_role = "captain" if is_captain else team_role
-                team_role = "co-captain" if is_co_cap else team_role
-                message_dict["team_role"] = team_role
+            message_data = []
+            for player in players:
+                player_name = await player.get_field(PlayerFields.player_name)
+                player_region = await player.get_field(PlayerFields.region)
+                player_id = await player.get_field(PlayerFields.record_id)
+                message_dict = {}
+                message_dict["player"] = player_name
+                message_dict["region"] = player_region
+                # Get cooldown info
+                cooldowns = await self._db.table_cooldown.get_cooldown_records(
+                    player_id=player_id
+                )
+                cooldown: CooldownRecord = cooldowns[0] if cooldowns else None
+                if cooldown:
+                    cooldown_end = await cooldown.get_field(CooldownFields.expires_at)
+                    message_dict["cooldown_end"] = cooldown_end
+                # Get Team info
+                team_players = await self._db.table_team_player.get_team_player_records(
+                    player_id=player_id
+                )
+                team_player = team_players[0] if team_players else None
+                if team_player:
+                    team_id = await team_player.get_field(TeamPlayerFields.team_id)
+                    teams = await self._db.table_team.get_team_records(
+                        record_id=team_id
+                    )
+                    assert teams, "Player team not found"
+                    team = teams[0] if teams else None
+                    team_name = await team.get_field(TeamFields.team_name)
+                    is_captain = await team_player.get_field(
+                        TeamPlayerFields.is_captain
+                    )
+                    is_co_cap = await team_player.get_field(
+                        TeamPlayerFields.is_co_captain
+                    )
+                    message_dict["team"] = team_name
+                    team_role = "member"
+                    team_role = "captain" if is_captain else team_role
+                    team_role = "co-captain" if is_co_cap else team_role
+                    message_dict["team_role"] = team_role
+                message_data.append(message_dict)
             # Create Response
-            message = await general_helpers.format_json(message_dict)
+            if len(message_data) == 1:
+                message_data = message_data[0]
+            message = await general_helpers.format_json(message_data)
             message = await discord_helpers.code_block(message, language="json")
             return await discord_helpers.final_message(interaction, message)
         except AssertionError as message:

--- a/Xena/bot_functions/manage_teams.py
+++ b/Xena/bot_functions/manage_teams.py
@@ -43,10 +43,11 @@ class ManageTeams:
             assert len(team_name) <= 32, f"Team name must be under 32 characters long."
             # Check if the Player is registered
             discord_id = interaction.user.id
-            player = await self._db.table_player.get_player_record(
+            players = await self._db.table_player.get_player_records(
                 discord_id=discord_id
             )
-            assert player, f"You must be registered as a player to create a team."
+            assert players, f"You must be registered as a player to create a team."
+            player = players[0]
             # Create Team and Captain Database Records
             player_id = await player.get_field(PlayerFields.record_id)
             new_team = await database_helpers.create_team(
@@ -79,22 +80,24 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get Player Record for inviter
-            inviter = await self._db.table_player.get_player_record(
+            inviter_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
             assert_message = f"You must be registered as a player to invite players."
-            assert inviter, assert_message
+            assert inviter_matches, assert_message
+            inviter = inviter_matches[0]
             # check permissions
             team_details = await database_helpers.get_team_details_from_player(
                 self._db, inviter, assert_captain=True
             )
             assert team_details, f"You must be a captain to invite players."
             # Get player record for invitee
-            invitee = await self._db.table_player.get_player_record(
+            invitee_matches = await self._db.table_player.get_player_records(
                 player_name=player_name
             )
             assert_message = f"Player `{player_name}` not found. Please check the spelling, and verify the player is registered."
-            assert invitee, assert_message
+            assert invitee_matches, assert_message
+            invitee = invitee_matches[0]
             # Create Invite record
             new_invite = await database_helpers.create_team_invite(
                 self._db, inviter, invitee
@@ -116,10 +119,11 @@ class ManageTeams:
         """Add the requestor to their new Team"""
         try:
             # Get info about the Player
-            player = await self._db.table_player.get_player_record(
+            players = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert player, f"You must be registered as a Player to accept an invite."
+            assert players, f"You must be registered as a Player to accept an invite."
+            player = players[0]
             player_id = await player.get_field(PlayerFields.record_id)
             # Gather Invites
             invites = await self._db.table_team_invite.get_team_invite_records(
@@ -212,11 +216,12 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get requestor's Team Details
-            requestor = await self._db.table_player.get_player_record(
+            requestor_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
             assert_message = f"You register as a player, and be cpatin of a team to remove players from it."
-            assert requestor, assert_message
+            assert requestor_matches, assert_message
+            requestor = requestor_matches[0]
             team_details = await database_helpers.get_team_details_from_player(
                 self._db, requestor, assert_captain=True
             )
@@ -224,12 +229,13 @@ class ManageTeams:
                 team_details
             ), f"You must be the captain of a team to remove players from it."
             # Verify Player exists
-            player = await self._db.table_player.get_player_record(
+            players = await self._db.table_player.get_player_records(
                 player_name=player_name
             )
-            player_name = await player.get_field(PlayerFields.player_name)
             assert_message = f"Player `{player_name}` not found. Please check the spelling, and verify the player is registered."
-            assert player, assert_message
+            assert players, assert_message
+            player = players[0]
+            player_name = await player.get_field(PlayerFields.player_name)
             # Remove Player from Team
             player_id = await player.get_field(PlayerFields.record_id)
             team_id = await team_details.team.get_field(TeamFields.record_id)
@@ -269,10 +275,13 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get info about the requestor
-            requestor = await self._db.table_player.get_player_record(
+            requestor_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert requestor, f"You must be registered as a player to promote players."
+            assert (
+                requestor_matches
+            ), f"You must be registered as a player to promote players."
+            requestor = requestor_matches[0]
             requestor_id = await requestor.get_field(PlayerFields.record_id)
             requestor_team_players = (
                 await self._db.table_team_player.get_team_player_records(
@@ -299,10 +308,11 @@ class ManageTeams:
                     )
             assert not co_captain_id, f"Team already has a co-captain."
             # Get info about the Player
-            player = await self._db.table_player.get_player_record(
+            players = await self._db.table_player.get_player_records(
                 player_name=player_name
             )
-            assert player, f"Player not found."
+            assert players, f"Player not found."
+            player = players[0]
             player_name = await player.get_field(PlayerFields.player_name)
             player_id = await player.get_field(PlayerFields.record_id)
             player_team_player = None
@@ -351,10 +361,13 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get info about the requestor
-            requestor = await self._db.table_player.get_player_record(
+            requestor_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert requestor, f"You must be registered as a player to demote players."
+            assert (
+                requestor_matches
+            ), f"You must be registered as a player to demote players."
+            requestor = requestor_matches[0]
             requestor_id = await requestor.get_field(PlayerFields.record_id)
             requestor_team_players = (
                 await self._db.table_team_player.get_team_player_records(
@@ -373,10 +386,11 @@ class ManageTeams:
                 team_id=team_id
             )
             # Get info about the Player
-            player = await self._db.table_player.get_player_record(
+            players = await self._db.table_player.get_player_records(
                 player_name=player_name
             )
-            assert player, f"Player not found."
+            assert players, f"Player not found."
+            player = players[0]
             player_name = await player.get_field(PlayerFields.player_name)
             player_id = await player.get_field(PlayerFields.record_id)
             player_team_player = None
@@ -422,10 +436,13 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get info about the requestor
-            requestor = await self._db.table_player.get_player_record(
+            requestor_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert requestor, f"You must be registered as a Player to leave a Team."
+            assert (
+                requestor_matches
+            ), f"You must be registered as a Player to leave a Team."
+            requestor = requestor_matches[0]
             requestor_player_id = await requestor.get_field(PlayerFields.record_id)
             requestor_team_players = (
                 await self._db.table_team_player.get_team_player_records(
@@ -439,7 +456,9 @@ class ManageTeams:
             )
             # Get info about the Team
             team_id = await requestor_team_player.get_field(TeamPlayerFields.team_id)
-            team = await self._db.table_team.get_team_record(record_id=team_id)
+            teams = await self._db.table_team.get_team_records(record_id=team_id)
+            assert teams, f"Team not found."
+            team = teams[0]
             team_name = await team.get_field(TeamFields.team_name)
             team_players = await self._db.table_team_player.get_team_player_records(
                 team_id=team_id
@@ -499,10 +518,13 @@ class ManageTeams:
             # This could take a while
             await interaction.response.defer()
             # Get info about the requestor
-            requestor = await self._db.table_player.get_player_record(
+            requestor_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert requestor, f"You must be registered as a player to disband a team."
+            assert (
+                requestor_matches
+            ), f"You must be registered as a player to disband a team."
+            requestor = requestor_matches[0]
             requestor_id = await requestor.get_field(PlayerFields.record_id)
             requestor_team_players = (
                 await self._db.table_team_player.get_team_player_records(
@@ -517,7 +539,9 @@ class ManageTeams:
             assert requestor_is_captain, f"You must be team captain to disband a team."
             # Get info about the Team
             team_id = await requestor_team_player.get_field(TeamPlayerFields.team_id)
-            team = await self._db.table_team.get_team_record(record_id=team_id)
+            teams = await self._db.table_team.get_team_records(record_id=team_id)
+            assert teams, f"Team not found."
+            team = teams[0]
             team_name = await team.get_field(TeamFields.team_name)
             team_players = await self._db.table_team_player.get_team_player_records(
                 team_id=team_id
@@ -527,9 +551,11 @@ class ManageTeams:
             for team_player in team_players:
                 # Remove Player's Discord roles
                 player_id = await team_player.get_field(TeamPlayerFields.player_id)
-                player = await self._db.table_player.get_player_record(
+                players = await self._db.table_player.get_player_records(
                     record_id=player_id
                 )
+                assert players, f"Player not found."
+                player = players[0]
                 player_discord_id = await player.get_field(PlayerFields.discord_id)
                 player_discord_member = await discord_helpers.member_from_discord_id(
                     guild=interaction.guild,
@@ -578,9 +604,13 @@ class ManageTeams:
             # Determine desired team
             team = None
             if not team_name:
-                requestor = await self._db.table_player.get_player_record(
+                requestor_matches = await self._db.table_player.get_player_records(
                     discord_id=interaction.user.id
                 )
+                assert (
+                    requestor_matches
+                ), f"You must provide a team name, or be on a team to get team details."
+                requestor = requestor_matches[0]
                 requestor_id = await requestor.get_field(PlayerFields.record_id)
                 team_players = await self._db.table_team_player.get_team_player_records(
                     player_id=requestor_id
@@ -588,10 +618,14 @@ class ManageTeams:
                 assert team_players, f"No team specified."
                 team_player = team_players[0]
                 team_id = await team_player.get_field(TeamPlayerFields.team_id)
-                team = await self._db.table_team.get_team_record(record_id=team_id)
+                teams = await self._db.table_team.get_team_records(record_id=team_id)
+                assert teams, f"Team not found."
+                team = teams[0]
             # Get info about the Team
             if not team:
-                team = await self._db.table_team.get_team_record(team_name=team_name)
+                teams = await self._db.table_team.get_team_records(team_name=team_name)
+                assert teams, f"Team not found."
+                team = teams[0]
             assert team, f"Team not found."
             team_name = await team.get_field(TeamFields.team_name)
             team_id = await team.get_field(TeamFields.record_id)
@@ -604,9 +638,11 @@ class ManageTeams:
             player_names = []
             for team_player in team_players:
                 player_id = await team_player.get_field(TeamPlayerFields.player_id)
-                player = await self._db.table_player.get_player_record(
+                players = await self._db.table_player.get_player_records(
                     record_id=player_id
                 )
+                assert players, f"Player not found."
+                player = players[0]
                 player_name = await player.get_field(PlayerFields.player_name)
                 player_names.append(player_name)
                 if await team_player.get_field(TeamPlayerFields.is_captain):

--- a/Xena/bot_functions/manage_teams.py
+++ b/Xena/bot_functions/manage_teams.py
@@ -73,7 +73,10 @@ class ManageTeams:
             await discord_helpers.error_message(interaction, error)
 
     async def invite_player_to_team(
-        self, interaction: discord.Interaction, player_name
+        self,
+        interaction: discord.Interaction,
+        player_name: str = None,
+        player_discord_id: str = None,
     ):
         """Invite a Player to a Team by name"""
         try:
@@ -83,8 +86,9 @@ class ManageTeams:
             inviter_matches = await self._db.table_player.get_player_records(
                 discord_id=interaction.user.id
             )
-            assert_message = f"You must be registered as a player to invite players."
-            assert inviter_matches, assert_message
+            assert (
+                inviter_matches
+            ), f"You must be registered as a player to invite players."
             inviter = inviter_matches[0]
             # check permissions
             team_details = await database_helpers.get_team_details_from_player(
@@ -93,10 +97,14 @@ class ManageTeams:
             assert team_details, f"You must be a captain to invite players."
             # Get player record for invitee
             invitee_matches = await self._db.table_player.get_player_records(
-                player_name=player_name
+                player_name=player_name, discord_id=player_discord_id
             )
-            assert_message = f"Player `{player_name}` not found. Please check the spelling, and verify the player is registered."
-            assert invitee_matches, assert_message
+            assert (
+                invitee_matches
+            ), f"Player not found. Please verify the player is registered."
+            assert (
+                len(invitee_matches) == 1
+            ), f"Multiple players found. Please specify the player's Discord ID (nubmers only) to invite them."
             invitee = invitee_matches[0]
             # Create Invite record
             new_invite = await database_helpers.create_team_invite(

--- a/Xena/database/table_player.py
+++ b/Xena/database/table_player.py
@@ -26,10 +26,10 @@ class PlayerTable(BaseTable):
     ) -> PlayerRecord:
         """Create a new Player record"""
         # Check for existing records to avoid duplication
-        existing_record = await self.get_player_record(
+        existing_records = await self.get_player_records(
             discord_id=discord_id, player_name=player_name
         )
-        if existing_record:
+        if existing_records:
             raise DbErrors.EmlRecordAlreadyExists(
                 f"Player '{player_name}' already exists"
             )
@@ -55,15 +55,16 @@ class PlayerTable(BaseTable):
         record_id = await record.get_field(PlayerFields.record_id)
         await self.delete_record(record_id)
 
-    async def get_player_record(
+    async def get_player_records(
         self, record_id: str = None, discord_id: str = None, player_name: str = None
-    ) -> PlayerRecord:
-        """Get an existing Player record"""
+    ) -> list[PlayerRecord]:
+        """Get existing Player records"""
         if record_id is None and discord_id is None and player_name is None:
             raise ValueError(
                 "At least one of 'record_id', 'discord_id', or 'player_name' is required"
             )
         table = await self.get_table_data()
+        existing_records = []
         for row in table:
             if table.index(row) == 0:
                 continue
@@ -84,9 +85,8 @@ class PlayerTable(BaseTable):
                     == str(row[PlayerFields.player_name]).casefold()
                 )
             ):
-                existing_record = PlayerRecord(row)
-                return existing_record
-        return None
+                existing_records.append(PlayerRecord(row))
+        return existing_records
 
     async def get_players_by_region(self, region: str) -> list[PlayerRecord]:
         """Get all players from a specific region"""

--- a/Xena/database/table_team.py
+++ b/Xena/database/table_team.py
@@ -25,8 +25,8 @@ class TeamTable(BaseTable):
     async def create_team_record(self, team_name: str, vw_region: str) -> TeamRecord:
         """Create a new Team record"""
         # Check for existing records to avoid duplication
-        existing_record = await self.get_team_record(team_name=team_name)
-        if existing_record:
+        existing_records = await self.get_team_records(team_name=team_name)
+        if existing_records:
             raise DbErrors.EmlRecordAlreadyExists(f"Team '{team_name}' already exists")
         # Create the Team record
         record_list = [None] * len(TeamFields)
@@ -47,13 +47,14 @@ class TeamTable(BaseTable):
         record_id = await record.get_field(TeamFields.record_id)
         await self.delete_record(record_id)
 
-    async def get_team_record(
+    async def get_team_records(
         self, record_id: str = None, team_name: str = None
-    ) -> TeamRecord:
+    ) -> list[TeamRecord]:
         """Get an existing Team record"""
         if record_id is None and team_name is None:
             raise ValueError("At least one of 'record_id' or 'team_name' is required")
         table = await self.get_table_data()
+        existing_records = []
         for row in table:
             if table.index(row) == 0:
                 continue
@@ -66,6 +67,5 @@ class TeamTable(BaseTable):
                 or str(team_name).casefold()
                 == str(row[TeamFields.team_name]).casefold()
             ):
-                existing_record = TeamRecord(row)
-                return existing_record
-        return None
+                existing_records.append(TeamRecord(row))
+        return existing_records

--- a/Xena/main.py
+++ b/Xena/main.py
@@ -158,10 +158,12 @@ async def bot_team_create(interaction: discord.Interaction, team_name: str):
 
 
 @bot.tree.command(name=f"{BOT_PREFIX}teamplayeradd")
-async def bot_team_invite_offer(interaction: discord.Interaction, player_name: str):
+async def bot_team_invite_offer(
+    interaction: discord.Interaction, player_name: str = None, discord_id: str = None
+):
     """Invite a player to join your Team"""
     if await manage_commands.is_command_enabled(interaction):
-        await manage_teams.invite_player_to_team(interaction, player_name)
+        await manage_teams.invite_player_to_team(interaction, player_name, discord_id)
 
 
 @bot.tree.command(name=f"{BOT_PREFIX}teaminviteaccept")


### PR DESCRIPTION
also cleans up queries to return all matching results, rather than the first.