### PR TITLE
Add ability to update certain link constants in the google sheet

### DIFF
--- a/src/eml-bot-arena/bot_helpers/__init__.py
+++ b/src/eml-bot-arena/bot_helpers/__init__.py
@@ -1,2 +1,3 @@
 from bot_helpers.command_log import command_log
 from bot_helpers.command_is_allowed import command_is_allowed
+from bot_helpers.get_constant import get_constant

--- a/src/eml-bot-arena/bot_helpers/get_constant.py
+++ b/src/eml-bot-arena/bot_helpers/get_constant.py
@@ -1,0 +1,36 @@
+from database.database_full import FullDatabase
+from database.fields import ConstantsFields
+from utils import discord_helpers
+import constants
+import discord
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def get_constant(
+    database: FullDatabase,
+    interaction: discord.Interaction,
+    constant_name: str,
+    default_str: str,
+    skip_db: bool = False,
+):
+    try:
+        record = None
+        retStr = default_str
+
+        if not skip_db:
+            constrecs = (
+                await database.table_constants.get_constants_records(
+                    constant_name)
+                )
+            record = constrecs[0] if constrecs else None
+
+        if record:
+            retStr = await record.get_field(ConstantsFields.value)
+
+        return retStr
+    # Errors
+    except Exception as error:
+        await discord_helpers.error_message(interaction, error)
+    return False

--- a/src/eml-bot-arena/constants.py
+++ b/src/eml-bot-arena/constants.py
@@ -94,6 +94,7 @@ LEAGUE_DB_TAB_TEAM = "Team"
 LEAGUE_DB_TAB_TEAM_INVITE = "TeamInvite"
 LEAGUE_DB_TAB_TEAM_PLAYER = "TeamPlayer"
 LEAGUE_DB_TAB_VW_ROSTER = "vwRoster"
+LEAGUE_DB_TAB_CONSTANTS = "Constants"
 LINK_ACCUMULATED_POINTS = "https://echomasterleague.com/eml-accumulated-points-ap-system/"  # Comment added to keep line long enough for the formatter to ignore
 LINK_ACTION_LIST = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRhkQIBw9ETybdGNVggWnAf9ueizzDMc0lbKcsDPQsD6c1jDd8p8u8OUwl5gdcR2M14KmCV6-eF03p4/pubhtml"
 LINK_BOT_COMMANDS = "https://echomasterleague.com/eml-bot-commands/"

--- a/src/eml-bot-arena/database/database_full.py
+++ b/src/eml-bot-arena/database/database_full.py
@@ -12,6 +12,7 @@ from database.table_team import TeamTable
 from database.table_team_invite import TeamInviteTable
 from database.table_team_player import TeamPlayerTable
 from database.table_vw_roster import VwRosterTable
+from database.table_constants import ConstantsTable
 import logging
 
 logger = logging.getLogger(__name__)
@@ -36,3 +37,5 @@ class FullDatabase:
         self.table_team_invite = TeamInviteTable(core_database)
         self.table_team_player = TeamPlayerTable(core_database)
         self.table_vw_roster = VwRosterTable(core_database)
+        self.table_constants = ConstantsTable(core_database)
+

--- a/src/eml-bot-arena/database/fields.py
+++ b/src/eml-bot-arena/database/fields.py
@@ -282,3 +282,15 @@ class LeagueSubMatchInviteFields(IntEnum):
     vw_sub = 9  # The name of the sub player
     vw_team = 10  # The name of the team
     vw_captain = 11  # The name of the captain
+
+### Constants ###
+# this table is designed to be manually edited, so no provision is provided for unique id's, timestamps, etc
+
+@verify(EnumCheck.UNIQUE, EnumCheck.CONTINUOUS)
+class ConstantsFields(IntEnum):
+    """Lookup for column numbers of fields in the Constants table"""
+
+    name = 0
+    value = 1
+
+

--- a/src/eml-bot-arena/database/records.py
+++ b/src/eml-bot-arena/database/records.py
@@ -15,6 +15,7 @@ from database.fields import (
     TeamInviteFields,
     TeamPlayerFields,
     VwRosterFields,
+    ConstantsFields,
 )
 from typing import Type
 import errors.database_errors as DbErrors
@@ -590,3 +591,22 @@ class LeagueSubMatchInviteRecord(BaseRecord):
     ):
         """Create a record from a list of data (e.g. from `gsheets`)"""
         super().__init__(data_list, fields)
+
+
+### Constants ###
+
+
+class ConstantsRecord(BaseRecord):
+    """Record class for table Example"""
+
+    fields: Type[ConstantsFields]
+
+    def __init__(
+        self,
+        data_list: list[int | float | str | None],
+        fields: Type[ConstantsFields] = ConstantsFields,
+    ):
+        """Create a record from a list of data (e.g. from `gsheets`)"""
+        super().__init__(data_list, fields)
+
+

--- a/src/eml-bot-arena/database/table_constants.py
+++ b/src/eml-bot-arena/database/table_constants.py
@@ -1,0 +1,51 @@
+from database.base_table import BaseTable
+from database.database_core import CoreDatabase
+from database.enums import Bool
+from database.fields import ConstantsFields
+from database.records import ConstantsRecord
+import constants
+import gspread
+import logging
+
+logger = logging.getLogger(__name__)
+
+"""
+Constants Table
+"""
+
+
+class ConstantsTable(BaseTable):
+    """A class to manipulate the Constants table in the database"""
+
+    _db: CoreDatabase
+    _worksheet: gspread.Worksheet
+
+    def __init__(self, db: CoreDatabase):
+        """Initialize the ConstantsLock Table class"""
+        super().__init__(
+            db,
+            constants.LEAGUE_DB_TAB_CONSTANTS,
+            ConstantsRecord,
+            ConstantsFields,
+        )
+    async def get_constants_records(
+        self, name: str = None
+    ) -> list[ConstantsRecord]:
+        """Get an existing Constants record"""
+        # Walk the table
+        table = await self.get_table_data()
+        existing_records = []
+        for row in table[1:]:  # skip header row
+            # Check for matched record
+            if (
+                (
+                    not name
+                    or str(name).casefold()
+                    == str(row[ConstantsFields.name]).casefold()
+                )
+            ):
+                # Add matched record
+                existing_record = ConstantsRecord(row)
+                existing_records.append(existing_record)
+        # Return matched records
+        return existing_records

--- a/src/eml-bot-arena/main.py
+++ b/src/eml-bot-arena/main.py
@@ -203,7 +203,9 @@ async def ranks(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_TEAM_RANKINGS
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_TEAM_RANKINGS", default_str=constants.LINK_TEAM_RANKINGS,
+            skip_db=False)
         await interaction.response.send_message(f"Team Rankings: <{link}>")
 
 
@@ -214,7 +216,9 @@ async def matches(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_LEAGUE_MATCHES
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_LEAGUE_MATCHES", default_str=constants.LINK_LEAGUE_MATCHES,
+            skip_db=False)
         await interaction.response.send_message(f"Upcoming Matches: <{link}>")
 
 
@@ -225,7 +229,9 @@ async def rosters(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_LEAGUE_ROSTER
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_LEAGUE_ROSTER", default_str=constants.LINK_LEAGUE_ROSTER,
+            skip_db=False)
         await interaction.response.send_message(f"Roster: <{link}>")
 
 
@@ -236,7 +242,9 @@ async def website(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_EML_WEBSITE
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_EML_WEBSITE", default_str=constants.LINK_EML_WEBSITE,
+            skip_db=False)
         await interaction.response.send_message(f"EML Website: <{link}>")
 
 
@@ -247,7 +255,9 @@ async def website(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_BOT_INSTRUCTIONS
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_BOT_INSTRUCTIONS", default_str=constants.LINK_BOT_INSTRUCTIONS,
+            skip_db=False)
         await interaction.response.send_message(f"Bot Instructions: <{link}>")
 
 
@@ -258,7 +268,9 @@ async def website(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_BOT_COMMANDS
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_BOT_COMMANDS", default_str=constants.LINK_BOT_COMMANDS,
+            skip_db=False)
         await interaction.response.send_message(f"Command Reference: <{link}>")
 
 
@@ -269,7 +281,9 @@ async def leaguerules(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_LEAGUE_RULES
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_LEAGUE_RULES", default_str=constants.LINK_LEAGUE_RULES,
+            skip_db=False)
         await interaction.response.send_message(f"League Rules: <{link}>")
 
 
@@ -280,7 +294,9 @@ async def coc(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_DISCORD_CHANNEL_EML_COC
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_DISCORD_CHANNEL_EML_COC", default_str=constants.LINK_DISCORD_CHANNEL_EML_COC,
+            skip_db=False)
         await interaction.response.send_message(f"EML Code of Conduct: <{link}>")
 
 
@@ -291,7 +307,9 @@ async def ticket(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_DISCORD_CHANNEL_EML_TICKETS
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_DISCORD_CHANNEL_EML_TICKETS", default_str=constants.LINK_DISCORD_CHANNEL_EML_TICKETS,
+            skip_db=False)
         await interaction.response.send_message(f"EML Tickets: <{link}>")
 
 
@@ -302,7 +320,9 @@ async def support(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_DISCORD_CHANNEL_EML_SUPPORT
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_DISCORD_CHANNEL_EML_SUPPORT", default_str=constants.LINK_DISCORD_CHANNEL_EML_SUPPORT,
+            skip_db=False)
         await interaction.response.send_message(f"EML Support (FAQ): <{link}>")
 
 
@@ -313,7 +333,9 @@ async def staff_app(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_STAFF_APPLICATION
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_STAFF_APPLICATION", default_str=constants.LINK_STAFF_APPLICATION,
+            skip_db=False)
         await interaction.response.send_message(f"Staff Application: <{link}>")
 
 
@@ -324,7 +346,9 @@ async def staff_app(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_CALENDAR_EU
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_CALENDAR_EU", default_str=constants.LINK_CALENDAR_EU,
+            skip_db=False)
         await interaction.response.send_message(f"**Europe**: [EU]({link})")
 
 
@@ -335,7 +359,9 @@ async def staff_app(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_CALENDAR_NA
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_CALENDAR_NA", default_str=constants.LINK_CALENDAR_NA,
+            skip_db=False)
         await interaction.response.send_message(f"**North America**: [NA]({link})")
 
 
@@ -346,7 +372,9 @@ async def ap(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_ACCUMULATED_POINTS
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_ACCUMULATED_POINTS", default_str=constants.LINK_ACCUMULATED_POINTS,
+            skip_db=False)
         await interaction.response.send_message(f"Accumlulated Points: <{link}>")
 
 
@@ -357,7 +385,9 @@ async def action_list(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link = constants.LINK_ACTION_LIST
+        link = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_ACTION_LIST", default_str=constants.LINK_ACTION_LIST,
+            skip_db=False)
         await interaction.response.send_message(f"Action List: <{link}>")
 
 
@@ -368,8 +398,12 @@ async def lounge_report(interaction: discord.Interaction):
     if await bot_helpers.command_is_allowed(
         database=db, interaction=interaction, skip_channel=True
     ):
-        link_lounge = constants.LINK_ECHO_VR_LOUNGE
-        link_report = constants.LINK_ECHO_VR_LOUNGE_TICKETS
+        link_lounge = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_ECHO_VR_LOUNGE", default_str=constants.LINK_ECHO_VR_LOUNGE,
+            skip_db=False)
+        link_report = await bot_helpers.get_constant(database=db, interaction=interaction,
+            constant_name="LINK_ECHO_VR_LOUNGE_TICKETS", default_str=constants.LINK_ECHO_VR_LOUNGE_TICKETS,
+            skip_db=False)
         await interaction.response.send_message(
             f"**Echo VR Lounge Reporting**:\n"
             f"Gameplay violations such as halfcycling, cheat engine, etc. need to reported with evidence in a ticket to the Echo VR Lounge. Any action taken by EVRL will be considered for action by the EML AP system.\n\n"


### PR DESCRIPTION
This adds a new google sheet table that should be named "Constants" and contain 2 columns: name, value. When a command is performed that would normally display a link from one of the specified constants, the code will instead try to load the constant from the constants tab of the google sheet.  If successful, the loaded value will be used instead of the value from constants.py.  The format of the "constants" tab is column A is a name that would match a constant name from constants.py, and column B is the value of the constant.  Database related python files added/updated to support the new table. bot_helpers/get_constant.py adds a new method for retrieving the database constant.  main.py altered to update the commands to use the get_constant() method.

The following constants are supported:

LINK_ACCUMULATED_POINTS
LINK_ACTION_LIST
LINK_BOT_COMMANDS
LINK_BOT_INSTRUCTIONS
LINK_CALENDAR_EU
LINK_CALENDAR_NA
LINK_DISCORD_CHANNEL_EML_COC
LINK_DISCORD_CHANNEL_EML_SUPPORT
LINK_DISCORD_CHANNEL_EML_TICKETS
LINK_ECHO_VR_LOUNGE
LINK_ECHO_VR_LOUNGE_TICKETS
LINK_EML_WEBSITE
LINK_LEAGUE_MATCHES
LINK_LEAGUE_ROSTER
LINK_LEAGUE_RULES
LINK_STAFF_APPLICATION
LINK_TEAM_RANKINGS